### PR TITLE
feat: remove problematic installation from the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,14 +12,6 @@ Plotting styles and helpers by LamaLab
 
 ## Installation
 
-### Option 1: Install from GitHub with pip
-
-```bash
-pip install git+https://github.com/lamalab-org/lama-aesthetics.git
-```
-
-### Option 2: Install from GitHub with pip
-
 ```bash
 # Clone the repository
 git clone https://github.com/lamalab-org/lama-aesthetics.git


### PR DESCRIPTION
The first option in the old README fails I do not know why

## Summary by Sourcery

Chores:
- Removes the first installation option from the README.