### PR TITLE
fix: solve the packaging to include the styles folder

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+include lama_aesthetics/styles/*.mplstyle
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,9 @@ requires-python = ">=3.10"
 readme = "README.md"
 license = { text = "MIT license" }
 
+[tool.setuptools.package-data]
+lama_aesthetics = ["styles/*.mplstyle"]
+
 [project.optional-dependencies]
 optional_dependencies = []
 all = ["lama-aesthetics[dev,docs]"]


### PR DESCRIPTION
## Summary by Sourcery

Include the styles directory in the package distribution by configuring package-data in pyproject.toml and adding a MANIFEST.in file

Build:
- Add [tool.setuptools.package-data] entry in pyproject.toml to include styles/*.mplstyle files
- Create MANIFEST.in to ensure the styles folder is included in source distributions