### PR TITLE
fix: correct `nice=True` behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,10 +156,10 @@ plt.show()
 |---|---|---|
 | `ax` | — | Matplotlib `Axes` object |
 | `x`, `y` | — | Data arrays (numeric or string/categorical) |
-| `pad` | `0.1` | Padding factor applied to both axes (only used when `nice=False`) |
+| `pad` | `0.1` | Padding factor applied to both axes. Expressed as a fraction of the spine range; the visible limits extend beyond the spine bounds by this amount. |
 | `pad_x` | `None` | Per-axis padding near the x-axis (vertical). Overrides `pad`. |
 | `pad_y` | `None` | Per-axis padding near the y-axis (horizontal). Overrides `pad`. |
-| `nice` | `True` | Snap numeric spine bounds to nice tick positions that bracket the data. When `True`, padding parameters are ignored for numeric axes. |
+| `nice` | `True` | Snap numeric spine bounds to nice tick positions that bracket the data. When `False`, spines span the raw data range instead. Padding is always applied regardless of this setting. |
 
 ### `ylabel_top` — horizontal y-label above the axis
 

--- a/src/lama_aesthetics/plotutils.py
+++ b/src/lama_aesthetics/plotutils.py
@@ -24,10 +24,10 @@ def _get_axis_bounds(values):
 def _nice_tick_bounds(data_min, data_max):
     """Return nice tick positions and spine bounds that strictly bracket the data.
 
-    Uses matplotlib's ``MaxNLocator`` to compute tick positions for the
+    Uses matplotlib's `MaxNLocator` to compute tick positions for the
     data range and then selects the outermost ticks as spine bounds.
     The returned bounds are guaranteed to satisfy
-    ``bound_lo <= data_min`` and ``bound_hi >= data_max``, and every
+    `bound_lo <= data_min` and `bound_hi >= data_max`, and every
     tick between the bounds (inclusive) is included.
 
     Args:
@@ -35,8 +35,8 @@ def _nice_tick_bounds(data_min, data_max):
         data_max: Maximum value present in the data.
 
     Returns:
-        ``(bound_lo, bound_hi, ticks)`` where *ticks* is a 1-D array of
-        the tick positions that fall within ``[bound_lo, bound_hi]``.
+        `(bound_lo, bound_hi, ticks)` where *ticks* is a 1-D array of
+        the tick positions that fall within `[bound_lo, bound_hi]`.
     """
     if data_min == data_max:
         # Degenerate case — expand symmetrically so the locator has a range.
@@ -67,18 +67,18 @@ def range_frame(ax, x, y, pad=0.1, pad_x=None, pad_y=None, nice=True):
     `pad` times the range of the data. This is useful to ensure that the data
     points are not cut off by the axes.
 
-    Per-axis padding can be controlled with ``pad_x`` and ``pad_y``.  When
-    either is *None* (the default) the value of ``pad`` is used instead.
+    Per-axis padding can be controlled with `pad_x` and `pad_y`.  When
+    either is *None* (the default) the value of `pad` is used instead.
 
-    When ``nice`` is *True* (the default) and the axis carries numerical
+    When `nice` is *True* (the default) and the axis carries numerical
     data, the spine bounds are snapped to nice tick positions that bracket
     the data, so that the axis line starts and ends exactly at tick marks.
-    Tick positions are computed via matplotlib's ``MaxNLocator`` and
+    Tick positions are computed via matplotlib's `MaxNLocator` and
     explicitly set on the axes so there is no drift between ticks and
-    spine endpoints.  When ``nice`` is *False*, the spines span the raw
+    spine endpoints.  When `nice` is *False*, the spines span the raw
     data range instead.
 
-    Regardless of ``nice``, the ``pad`` / ``pad_x`` / ``pad_y`` parameters
+    Regardless of `nice`, the `pad` / `pad_x` / `pad_y` parameters
     control how far the visible axis limits extend beyond the spine bounds,
     giving data points breathing room from the spine edges.
 
@@ -88,8 +88,8 @@ def range_frame(ax, x, y, pad=0.1, pad_x=None, pad_y=None, nice=True):
         y: The y-coordinates of the data points.
         pad: The default padding factor applied to both axes.  Expressed as
             a fraction of the spine range.
-        pad_x: Padding near the x-axis (vertical direction). Overrides ``pad`` when set.
-        pad_y: Padding near the y-axis (horizontal direction). Overrides ``pad`` when set.
+        pad_x: Padding near the x-axis (vertical direction). Overrides `pad` when set.
+        pad_y: Padding near the y-axis (horizontal direction). Overrides `pad` when set.
         nice: If *True* (default), snap numeric spine bounds to nice tick
             positions that bracket the data.  If *False*, spines span the
             raw data range.
@@ -327,17 +327,17 @@ def decompose_figure(
     bar group, fill, …) together with the same axis labels, limits, and
     title as the original.  Only artists that carry a label (and would
     therefore appear in a legend) are considered; artists whose label
-    starts with ``_`` are skipped, following the matplotlib convention.
+    starts with `_` are skipped, following the matplotlib convention.
 
     Args:
         fig_or_ax: A :class:`~matplotlib.figure.Figure` or a single
             :class:`~matplotlib.axes.Axes` instance.  When a *Figure*
-            is given the first ``Axes`` is used.
+            is given the first `Axes` is used.
         show_legend: If *True* (default) a legend is added to every
             decomposed figure.
 
     Returns:
-        A list of ``(label, figure)`` tuples where *label* is the
+        A list of `(label, figure)` tuples where *label* is the
         legend text associated with the artist and *figure* is a new
         :class:`~matplotlib.figure.Figure` containing only that artist.
 

--- a/src/lama_aesthetics/plotutils.py
+++ b/src/lama_aesthetics/plotutils.py
@@ -75,18 +75,24 @@ def range_frame(ax, x, y, pad=0.1, pad_x=None, pad_y=None, nice=True):
     the data, so that the axis line starts and ends exactly at tick marks.
     Tick positions are computed via matplotlib's ``MaxNLocator`` and
     explicitly set on the axes so there is no drift between ticks and
-    spine endpoints.  The ``pad`` / ``pad_x`` / ``pad_y`` parameters are
-    ignored for any axis that receives nice bounds.
+    spine endpoints.  When ``nice`` is *False*, the spines span the raw
+    data range instead.
+
+    Regardless of ``nice``, the ``pad`` / ``pad_x`` / ``pad_y`` parameters
+    control how far the visible axis limits extend beyond the spine bounds,
+    giving data points breathing room from the spine edges.
 
     Args:
         ax: The axes object.
         x: The x-coordinates of the data points.
         y: The y-coordinates of the data points.
-        pad: The default padding factor applied to both axes.
+        pad: The default padding factor applied to both axes.  Expressed as
+            a fraction of the spine range.
         pad_x: Padding near the x-axis (vertical direction). Overrides ``pad`` when set.
         pad_y: Padding near the y-axis (horizontal direction). Overrides ``pad`` when set.
         nice: If *True* (default), snap numeric spine bounds to nice tick
-            positions that bracket the data.
+            positions that bracket the data.  If *False*, spines span the
+            raw data range.
     """
     if pad_x is None:
         pad_x = pad
@@ -101,11 +107,11 @@ def range_frame(ax, x, y, pad=0.1, pad_x=None, pad_y=None, nice=True):
         if nice:
             y_bound_min, y_bound_max, y_ticks = _nice_tick_bounds(y_min, y_max)
             ax.set_yticks(y_ticks)
-            ax.set_ylim(y_bound_min, y_bound_max)
         else:
             y_bound_min = y_min
             y_bound_max = y_max
-            ax.set_ylim(y_min - pad_x * (y_max - y_min), y_max + pad_x * (y_max - y_min))
+        y_range = y_bound_max - y_bound_min
+        ax.set_ylim(y_bound_min - pad_x * y_range, y_bound_max + pad_x * y_range)
     else:
         y_bound_min, y_bound_max = y_min, y_max
         ax.set_ylim(y_min, y_max)
@@ -115,11 +121,11 @@ def range_frame(ax, x, y, pad=0.1, pad_x=None, pad_y=None, nice=True):
         if nice:
             x_bound_min, x_bound_max, x_ticks = _nice_tick_bounds(x_min, x_max)
             ax.set_xticks(x_ticks)
-            ax.set_xlim(x_bound_min, x_bound_max)
         else:
             x_bound_min = x_min
             x_bound_max = x_max
-            ax.set_xlim(x_min - pad_y * (x_max - x_min), x_max + pad_y * (x_max - x_min))
+        x_range = x_bound_max - x_bound_min
+        ax.set_xlim(x_bound_min - pad_y * x_range, x_bound_max + pad_y * x_range)
     else:
         x_bound_min, x_bound_max = x_min, x_max
         ax.set_xlim(x_min, x_max)

--- a/tests/test_plotutils.py
+++ b/tests/test_plotutils.py
@@ -27,6 +27,69 @@ def test_range_frame():
     assert ylim[0] <= y.min()
     assert ylim[1] >= y.max()
 
+    # Spines snap to nice tick bounds
+    x_spine = ax.spines["bottom"].get_bounds()
+    y_spine = ax.spines["left"].get_bounds()
+    assert x_spine[0] <= x.min()
+    assert x_spine[1] >= x.max()
+    assert y_spine[0] <= y.min()
+    assert y_spine[1] >= y.max()
+
+    # Pad (default 0.1) means the visible limits extend beyond the spine bounds
+    assert xlim[0] < x_spine[0]
+    assert xlim[1] > x_spine[1]
+    assert ylim[0] < y_spine[0]
+    assert ylim[1] > y_spine[1]
+
+    plt.close(fig)
+
+
+def test_range_frame_nice_true_with_pad():
+    """Test that pad is respected even when nice=True."""
+    fig, ax = plt.subplots()
+    x = np.array([1, 2, 3, 4, 5])
+    y = np.array([10, 20, 30, 40, 50])
+
+    range_frame(ax, x, y, pad=0.2, nice=True)
+
+    xlim = ax.get_xlim()
+    ylim = ax.get_ylim()
+
+    # Spine bounds come from nice ticks
+    x_spine = ax.spines["bottom"].get_bounds()
+    y_spine = ax.spines["left"].get_bounds()
+
+    # Limits must extend beyond spine bounds by the pad fraction
+    x_range = x_spine[1] - x_spine[0]
+    y_range = y_spine[1] - y_spine[0]
+
+    assert abs(xlim[0] - (x_spine[0] - 0.2 * x_range)) < 1e-10
+    assert abs(xlim[1] - (x_spine[1] + 0.2 * x_range)) < 1e-10
+    assert abs(ylim[0] - (y_spine[0] - 0.2 * y_range)) < 1e-10
+    assert abs(ylim[1] - (y_spine[1] + 0.2 * y_range)) < 1e-10
+
+    plt.close(fig)
+
+
+def test_range_frame_nice_true_pad_zero():
+    """When pad=0 and nice=True, limits should equal the spine bounds exactly."""
+    fig, ax = plt.subplots()
+    x = np.array([1, 2, 3, 4, 5])
+    y = np.array([10, 20, 30, 40, 50])
+
+    range_frame(ax, x, y, pad=0.0, nice=True)
+
+    xlim = ax.get_xlim()
+    ylim = ax.get_ylim()
+
+    x_spine = ax.spines["bottom"].get_bounds()
+    y_spine = ax.spines["left"].get_bounds()
+
+    assert abs(xlim[0] - x_spine[0]) < 1e-10
+    assert abs(xlim[1] - x_spine[1]) < 1e-10
+    assert abs(ylim[0] - y_spine[0]) < 1e-10
+    assert abs(ylim[1] - y_spine[1]) < 1e-10
+
     plt.close(fig)
 
 


### PR DESCRIPTION
## Summary by Sourcery

Adjust range_frame axis limit handling so padding is consistently applied relative to spine bounds, and expand tests and documentation to reflect the corrected nice=True behavior.

Enhancements:
- Apply padding to axis limits based on spine ranges for both nice and non-nice modes, ensuring consistent breathing room around the data.
- Clarify range_frame docstring to distinguish between spine bounds and visible limits and to document nice=False behavior more precisely.

Documentation:
- Update README documentation for range_frame to describe padding semantics relative to spine bounds and clarify interaction with the nice parameter.

Tests:
- Add tests verifying that spine bounds follow nice tick positions while visible limits respect pad, including pad>0 and pad=0 cases when nice=True.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Axis padding now consistently extends visible limits beyond spine/data bounds regardless of tick-snapping mode.

* **Documentation**
  * Clarified padding semantics: expressed as fraction of spine range, pad_x/pad_y override pad, and padding always applies even when nice is enabled.

* **Tests**
  * Added tests verifying spine bounds, padding effects, and behavior with/without nice tick snapping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->